### PR TITLE
Fix Cult floor now actually atmos proof (#3123)

### DIFF
--- a/code/game/turfs/open/floor/plasteel_floor.dm
+++ b/code/game/turfs/open/floor/plasteel_floor.dm
@@ -110,14 +110,6 @@
 /turf/open/floor/plasteel/cult
 	icon_state = "cult"
 	name = "engraved floor"
-	CanAtmosPass = ATMOS_PASS_NO	
-	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
-	
-/turf/open/floor/plasteel/cult/Initialize()
-	..()
-	var/datum/gas_mixture/auto_atmos = new (initial_gas_mix)
-	assume_air(auto_atmos)
-	update_air_ref()
 
 /turf/open/floor/plasteel/vaporwave
 	icon_state = "pinkblack"

--- a/code/game/turfs/open/floor/reinf_floor.dm
+++ b/code/game/turfs/open/floor/reinf_floor.dm
@@ -153,6 +153,8 @@
 	icon_state = "plating"
 	floor_tile = null
 	var/obj/effect/clockwork/overlay/floor/bloodcult/realappearance
+	CanAtmosPass = ATMOS_PASS_NO
+	CanAtmosPassVertical =	ATMOS_PASS_NO
 
 
 /turf/open/floor/engine/cult/Initialize()


### PR DESCRIPTION
* atmospass check to no for cult floor

* incase this ever gets used on a multizlevel map

* partially reverts #2988

reverts the space ruin cult floor beeing atmos prof again<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fix Cult floor now actually atmos proof 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
