### PR TITLE
The de-duplication

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -124186,14 +124186,6 @@ ugW
 ugW
 qDo
 acP
-oNJ
-ugW
-ugW
-frZ
-ugW
-ugW
-qDo
-acP
 acP
 agy
 vlx


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This un-corrupts Metastation map. The map had been damaged by duplicated entry introduced here: https://github.com/Oasis-SS13/Oasis-SS13/commit/677ad80293c2720aac82edb9d0bd38ffda051c34#diff-29356bec23b45cbd582f3f3dce38d11fd09ce2c98d3f0419bc59e6bbd4dffe72

Since each entry means one tile, aforementioned commit inserted vertically eight tiles beneath the pool and that insertion pushed tiles under them for 8 tiles, rendering Meta broken.

![Meta map corruption explained](https://user-images.githubusercontent.com/8010007/103859368-4c2e9000-50fd-11eb-9881-2770601d53be.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Meta no longer broken

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Metastation map has been fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
