### PR TITLE
adds analyzer to room and few minor changes

### DIFF
--- a/_maps/RandomRooms/Meta/sk_ren003Meta.dmm
+++ b/_maps/RandomRooms/Meta/sk_ren003Meta.dmm
@@ -649,6 +649,7 @@
 /area/maintenance/starboard/fore)
 "qP" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "qW" = (
@@ -853,8 +854,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vc" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/reactor_control)
 "vd" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -1021,6 +1027,9 @@
 /area/engine/engineering/reactor_core)
 "yW" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -1617,10 +1626,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
-"QP" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "QQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1882,14 +1887,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
-"ZR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering/reactor_control)
 
 (1,1,1) = {"
 Cq
@@ -1956,7 +1953,7 @@ tf
 Sa
 lU
 LF
-ZR
+vc
 Ux
 tT
 LF
@@ -2270,7 +2267,7 @@ VJ
 cY
 pd
 VJ
-rx
+aC
 aC
 aC
 aC
@@ -2296,7 +2293,7 @@ cY
 VJ
 VJ
 VJ
-vc
+aC
 EQ
 EQ
 EQ
@@ -2310,7 +2307,7 @@ EQ
 EQ
 EQ
 EQ
-rx
+aC
 VJ
 EQ
 VJ
@@ -2321,7 +2318,7 @@ hb
 VJ
 VJ
 VJ
-vc
+aC
 EQ
 GR
 Fa
@@ -2335,7 +2332,7 @@ Fa
 Fa
 Vz
 EQ
-rx
+aC
 EQ
 VJ
 VJ
@@ -2346,7 +2343,7 @@ Tv
 VJ
 VJ
 VJ
-QP
+ji
 Tv
 Jm
 Fa

--- a/_maps/RandomRooms/Meta/sk_ren003Meta.dmm
+++ b/_maps/RandomRooms/Meta/sk_ren003Meta.dmm
@@ -33,10 +33,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -357,6 +353,7 @@
 /area/engine/engineering/reactor_core)
 "iq" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/item/twohanded/required/fuel_rod,
 /turf/open/indestructible/sound/pool,
 /area/engine/engineering/reactor_core)
 "iu" = (
@@ -383,7 +380,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
 "iW" = (
-/obj/item/twohanded/required/fuel_rod,
 /turf/open/indestructible/sound/pool,
 /area/engine/engineering/reactor_core)
 "jf" = (
@@ -634,6 +630,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/item/analyzer,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
 "qD" = (
@@ -680,10 +677,6 @@
 /area/engine/engineering/reactor_control)
 "rw" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -1017,12 +1010,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -25
-	},
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
@@ -1319,6 +1312,11 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -26;
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering/reactor_control)
@@ -1884,6 +1882,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering/reactor_core)
+"ZR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering/reactor_control)
 
 (1,1,1) = {"
 Cq
@@ -1950,7 +1956,7 @@ tf
 Sa
 lU
 LF
-tf
+ZR
 Ux
 tT
 LF


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds a analyzer to Nuke room so you can know whats in pipe before turning it on
and few cosmetic changes such as moves fire alarms and moves a rod so dont have to swim in rad water to reach it

## Why It's Good For The Game
makes sense

![image](https://user-images.githubusercontent.com/56616002/108254281-b7cf3880-7152-11eb-888d-960f43c75a60.png)

## Changelog
:cl:
add: Analyzer to nuke reactor and minor changes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
