### PR TITLE
Minor change to reproductive extracts

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/reproductive.dm
+++ b/code/modules/research/xenobiology/crossbreeding/reproductive.dm
@@ -19,14 +19,17 @@ Reproductive extracts:
 		to_chat(user, "<span class='warning'>[src] is still digesting!</span>")
 		return
 	if(istype(O, /obj/item/storage/bag/bio))
-		var/list/inserted = list()
-		SEND_SIGNAL(O, COMSIG_TRY_STORAGE_TAKE_TYPE, /obj/item/reagent_containers/food/snacks/monkeycube, src, 1, null, null, user, inserted)
-		if(inserted.len)
-			var/obj/item/reagent_containers/food/snacks/monkeycube/M = inserted[1]
-			if(istype(M))
-				eat_cube(M, user)
-		else
+		var cube_eaten = FALSE
+		for(var/obj/item/reagent_containers/food/snacks/monkeycube/S in O.contents)
+			if(istype(S))
+				cube_eaten = TRUE
+				eat_cube(S, user)
+				if (cubes_eaten >= 3)
+					break
+		if (cube_eaten == FALSE)
 			to_chat(user, "<span class='warning'>There are no monkey cubes in the bio bag!</span>")
+		//SEND_SIGNAL(O, COMSIG_TRY_STORAGE_TAKE_TYPE, /obj/item/reagent_containers/food/snacks/monkeycube, src, 1, null, null, user, inserted)
+
 	if(istype(O,/obj/item/reagent_containers/food/snacks/monkeycube))
 		eat_cube(O, user)
 	if(cubes_eaten >= 3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Reproductive extracts take as many monkey cubes from bio bags as they need before spewing out extracts

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Minor QoL change, replaces the singular check for monkey cubes when clicked with bio bags with a loop, of 3 (max) - cubes already inserted.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

tweak: Reproductive extracts take as many monkey cubes from bio bags as they need before spewing out extracts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
