### PR TITLE
Turns the Ash Lizards into Ash Kobolds, Neighbors of the Ash Dwarves

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -78,3 +78,11 @@
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_NOGUNS,TRAIT_NOBREATH)
 	species_language_holder = /datum/language_holder/lizard/ash
+
+/datum/species/lizard/ashwalker/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
+  . = ..() //call everything from species/on_species_gain()
+  C.dna.add_mutation(DWARFISM)
+
+/datum/species/lizard/ashwalker/on_species_loss(mob/living/carbon/C, datum/species/old_species, pref_load)
+  . = ..() //call everything from species/on_species_gain()
+  C.dna.remove_mutation(DWARFISM)


### PR DESCRIPTION
## About The Pull Request

Ash lizards are boring, draft, common, overused. Ash Kobolds? That's the spice. New, evil, more distinguishable from the actual lizard miners.

A bastard Kobold is a fun one.

![kobold king](https://user-images.githubusercontent.com/27740099/95035012-de4b7600-0680-11eb-81db-11be5636a6ab.png)


## Why It's Good For The Game

**_Kobold.- (in Germanic mythology) a spirit that haunts houses or lives underground in caves or mines._** 

Fantasy kobolds fit the slot for what ash lizards are. In fantasy, Kobolds are mining mooks that commit horrible tribal atrocities such as eating humanoids and being a nuisance in caves and mines. They are the best miners in fantasy, outpacing even Dwarves (but not matching their intellect). They also worship dragons. We have dragons. Now we should have kobolds. 

![kobold](https://user-images.githubusercontent.com/27740099/95035696-1e135d00-0683-11eb-9f92-76eb0076f886.png)

## Changelog
:cl:
add: Gave the Ash lizard Subspecies Dwarfism.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
