### PR TITLE
Makes Plasmeme CE helmet match Hardsuit

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -303,6 +303,8 @@
 	desc = "An envirohelmet designed for the chief engineer. It reeks of poly and plasma."
 	icon_state = "ce_envirohelm"
 	item_state = "ce_envirohelm"
+	armor = list("melee" = 40, "bullet" = 5, "laser" = 10, "energy" = 15, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 90)
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 
 /obj/item/clothing/head/helmet/space/plasmaman/cmo
 	name = "chief medical officers envirohelmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Plasmemes CE helmet fireproof and heat proof

## Why It's Good For The Game

one of the cool things about being Plasmeme is the look, when your the CE your given a cool helmet that only you get BUT it isnt heatproof so when you need to go to put out a plasma flood etc you have to put your cool helmet away, which is disadvantageous if say your in crit and dr heals you, takes helemt off and you burn to death etc etc

![image](https://user-images.githubusercontent.com/56616002/110167939-654a7900-7dee-11eb-8a87-bdc91576cab2.png)
 
special thanks to oasis admins and players for murdering me when i asked to test it on server, was very helpful

## Changelog
:cl:
balance: Made CE helmet fire/heat proof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
