### PR TITLE
Adds hardsuit benefits to plasmemes helmets

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -151,7 +151,7 @@
 	desc = "A plasmaman containment helmet designed for security officers, protecting them from being flashed and burning alive, along-side other undesirables."
 	icon_state = "security_envirohelm"
 	item_state = "security_envirohelm"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 100, "acid" = 75)
+	armor = list("melee" = 35, "bullet" = 15, "laser" = 30, "energy" = 40, "bomb" = 10, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 75)
 
 /obj/item/clothing/head/helmet/space/plasmaman/security/warden
 	name = "warden's plasma envirosuit helmet"
@@ -219,6 +219,7 @@
 	desc = "A space-worthy helmet specially designed for atmos technician plasmamen, the usual purple stripes being replaced by engineering's blue."
 	icon_state = "atmos_envirohelm"
 	item_state = "atmos_envirohelm"
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 
 /obj/item/clothing/head/helmet/space/plasmaman/cargo
 	name = "cargo plasma envirosuit helmet"
@@ -297,6 +298,9 @@
 	desc = "A helmet issued to the head of the command staff. Sleak and Stylish, as all captains should be."
 	icon_state = "command_envirohelm"
 	item_state = "command_envirohelm"
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 50, "energy" = 60, "bomb" = 50, "bio" = 100, "rad" = 50, "fire" = 100, "acid" = 100)
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT //this needed to be added a long fucking time ago
 
 /obj/item/clothing/head/helmet/space/plasmaman/engineering/ce
 	name = "chief engineers envirohelmet"
@@ -311,18 +315,26 @@
 	desc = "A helmet issued to the head of the command staff. Sleak and Stylish, as all captains should be."
 	icon_state = "cmo_envirohelm"
 	item_state = "cmo_envirohelm"
+	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 15, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 75)
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SHOWEROKAY | SNUG_FIT | SCAN_REAGENTS
 
 /obj/item/clothing/head/helmet/space/plasmaman/security/hos
 	name = "head of securitys helmet"
 	desc = "A reinforced envirohelmet issued to the head of the security staff. You'll need it."
 	icon_state = "hos_envirohelm"
 	item_state = "hos_envirohelm"
+	armor = list("melee" = 45, "bullet" = 25, "laser" = 30, "energy" = 40, "bomb" = 25, "bio" = 100, "rad" = 50, "fire" = 95, "acid" = 95)
 
 /obj/item/clothing/head/helmet/space/plasmaman/rd
 	name = "research directors envirosuit helmet"
 	desc = "A custom made envirosuit helmet made using advanced nanofibers. Fashionable and easy to wear."
 	icon_state = "rd_envirohelm"
 	item_state = "rd_envirohelm"
+	resistance_flags = ACID_PROOF | FIRE_PROOF
+	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
+	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 15, "bomb" = 100, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 80)
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SHOWEROKAY | SNUG_FIT | SCAN_REAGENTS
+	actions_types = list(/datum/action/item_action/toggle_helmet_light, /datum/action/item_action/toggle_welding_screen/plasmaman, /datum/action/item_action/toggle_research_scanner)
 
 /obj/item/clothing/head/helmet/space/plasmaman/hop
 	name = "head of personnels envirosuit helmet"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the buffs of the hardsuit HELMETS to plasmeme versions e.g CAPs helmet is now tempproof acid proof and provides a small brute buff etc


## Why It's Good For The Game

why should a plasmeme head of staff be held back by his helmet, yes they now have a slight buff when they arnt wearing the hardsuit but thats only to the head, i personally feel its not a big issue, plasmemes weak and sow as is

image of plasmemes wearing helmets and not burning (note the R&D has the research scanner attached to his helmet like the hardsuit version)
![image](https://user-images.githubusercontent.com/56616002/110190776-e882c380-7e1c-11eb-8dc9-425d02aa1cc5.png)

each head and atmos tech wearing helmet and their normal outfit and a copy wearing hardsuit
![image](https://user-images.githubusercontent.com/56616002/110190813-27187e00-7e1d-11eb-8189-8f5bb1b25569.png)

the aftermath
![image](https://user-images.githubusercontent.com/56616002/110190827-339cd680-7e1d-11eb-8d53-5327cc183617.png)

humans in hos and cmo suits
![image](https://user-images.githubusercontent.com/56616002/110191003-36e49200-7e1e-11eb-9df5-c7957ceb8cfb.png)



## Changelog
:cl:
balance: added hardsuit helmet buffs to Plasmeme head of staffs helmets
fix: fixed atmos plasmeme helmet not being heat proof
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
