### PR TITLE
adds Cuban Pete and plushie to box and meta

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1450,13 +1450,7 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "adq" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/obj/item/instrument/eguitar{
-	pixel_x = 5
-	},
+/obj/machinery/vending/citadelplush,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "ads" = (
@@ -15478,8 +15472,7 @@
 /area/crew_quarters/bar)
 "aQb" = (
 /obj/structure/window/reinforced,
-/obj/structure/table/wood,
-/obj/item/instrument/violin,
+/obj/machinery/vending/classicbeats,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "aQc" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -39887,8 +39887,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/monocle,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "byM" = (
@@ -44780,8 +44778,8 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "bIC" = (
-/obj/structure/table/wood,
 /obj/machinery/light/small,
+/obj/structure/table/wood,
 /obj/item/clothing/glasses/regular/hipster{
 	name = "Hipster Glasses"
 	},
@@ -78405,6 +78403,7 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
+/obj/item/soap/nanotrasen,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dhZ" = (
@@ -78428,10 +78427,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/item/instrument/guitar,
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
+/obj/item/clothing/glasses/monocle,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dic" = (
@@ -78458,14 +78457,13 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "dif" = (
-/obj/item/soap/nanotrasen,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/table/wood,
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
+/obj/machinery/vending/classicbeats,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dig" = (
@@ -78494,14 +78492,13 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "dij" = (
-/obj/item/instrument/violin,
-/obj/structure/table/wood,
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/machinery/vending/citadelplush,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dik" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds both Cuban Pete and Citadel vending machine (music and plushie) to box and meta
![map](https://user-images.githubusercontent.com/56616002/111075074-1f706d80-84de-11eb-9080-ac8d2d699386.png)

![map](https://user-images.githubusercontent.com/56616002/111075105-462ea400-84de-11eb-8e79-b0972e03fd2d.png)


## Why It's Good For The Game

adds music and plushies for clowns to mess about with

## Changelog
:cl:
add: Added plushie and music vending machines to rest of the maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
