### PR TITLE
Revertion of radnerf.

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -61,6 +61,9 @@
 
 #define INVERSE(x) ( 1/(x) )
 
+/// Used for calculating the radioactive strength falloff
+#define INVERSE_SQUARE(initial_strength,cur_distance,initial_distance) ( (initial_strength)*((initial_distance)**2/(cur_distance)**2) )
+
 #define ISABOUTEQUAL(a, b, deviation) (deviation ? abs((a) - (b)) <= deviation : abs((a) - (b)) <= 0.1)
 
 #define ISEVEN(x) (x % 2 == 0)

--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -38,26 +38,14 @@ Ask ninjanomnom if they're around
 #define RAD_FULL_INSULATION 0						// Unused
 
 // WARNING: The defines below could have disastrous consequences if tweaked incorrectly. See: The great SM purge of Oct.6.2017
-// contamination_chance = 		[doesn't matter, will always contaminate]
-// contamination_strength = 	strength * RAD_CONTAMINATION_STR_COEFFICIENT
-// contamination_threshold =	1 / (RAD_CONTAMINATION_BUDGET_SIZE * RAD_CONTAMINATION_STR_COEFFICIENT)
-#define RAD_CONTAMINATION_BUDGET_SIZE 0.2			// Mob and non-mob budgets each gets a share from the radiation as large as this;
-													// So this means 10% of the rads is "absorbed" by non-mobs (if there is a non-mob),
-													// and another 10% of the rads is "absorbed" by mobs (if there is a mob)
+// contamination_chance = 		(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1/(steps*RAD_DISTANCE_COEFFICIENT), 1))
+// contamination_strength = 	(strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
+#define RAD_MINIMUM_CONTAMINATION 350				// How strong does a radiation wave have to be to contaminate objects
+#define RAD_CONTAMINATION_CHANCE_COEFFICIENT 0.01	// Higher means higher strength scaling contamination chance
+#define RAD_CONTAMINATION_STR_COEFFICIENT 0.20		// Higher means higher strength scaling contamination strength
+
 #define RAD_DISTANCE_COEFFICIENT 1					// Lower means further rad spread
 
-#define RAD_DISTANCE_COEFFICIENT_COMPONENT_MULTIPLIER 2	// Radiation components have additional penalty at distance coefficient
-														// This is to reduce radiation by contaminated objects, mostly
-
-#define RAD_HALF_LIFE 60							// The half-life of contaminated objects
-
+#define RAD_HALF_LIFE 45							// The half-life of contaminated objects
 #define RAD_WAVE_MINIMUM 10							// Radiation waves with less than this amount of power stop spreading
 													// WARNING: Reducing can make rads subsytem more expensive
-#define RAD_COMPONENT_MINIMUM 1						// To ensure slow contamination
-													// WARNING: Reducing can make rads subsytem more expensive
-#define RAD_CONTAMINATION_STR_COEFFICIENT (1 / RAD_HALF_LIFE / 8 * RAD_DISTANCE_COEFFICIENT_COMPONENT_MULTIPLIER ** 2)
-													// Higher means higher strength scaling contamination strength
-													// This number represents perservation of radiation
-													// Set to control the most typical situation: clutters around typical radiation sources
-													// This define is long and ugly because of the amount of math involved
-													// and to free this define from mathematical errors of future define number tweakers

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -29,23 +29,25 @@
 /proc/radiation_pulse(atom/source, intensity, range_modifier, log=FALSE, can_contaminate=TRUE)
 	if(!SSradiation.can_fire)
 		return
-	
-	var/list/things = get_rad_contents(isturf(source) ? source : get_turf(source)) //copypasta because I don't want to put special code in waves to handle their origin
+
+	if(intensity >= RAD_WAVE_MINIMUM) // Don't bother to spawn rad waves if they're just going to immediately go out
+		for(var/dir in GLOB.cardinals)
+			new /datum/radiation_wave(source, dir, intensity, range_modifier, can_contaminate)
+
+	var/list/things = get_rad_contents(source) //copypasta because I don't want to put special code in waves to handle their origin
+
 	for(var/k in 1 to things.len)
 		var/atom/thing = things[k]
 		if(!thing)
 			continue
 		thing.rad_act(intensity)
 
-	if(intensity >= RAD_WAVE_MINIMUM) // Don't bother to spawn rad waves if they're just going to immediately go out
-		new /datum/radiation_wave(source, intensity, range_modifier, can_contaminate)
+	var/static/last_huge_pulse = 0
+	if(intensity > 3000 && world.time > last_huge_pulse + 200)
+		last_huge_pulse = world.time
+		log = TRUE
+	if(log)
+		var/turf/_source_T = isturf(source) ? source : get_turf(source)
+		log_game("Radiation pulse with intensity: [intensity] and range modifier: [range_modifier] in [loc_name(_source_T)] ")
 
-		var/static/last_huge_pulse = 0
-		if(intensity > 3000 && world.time > last_huge_pulse + 200)
-			last_huge_pulse = world.time
-			log = TRUE
-		if(log)
-			var/turf/_source_T = isturf(source) ? source : get_turf(source)
-			log_game("Radiation pulse with intensity: [intensity] and range modifier: [range_modifier] in [loc_name(_source_T)] ")
-	
 	return TRUE

--- a/code/datums/components/rad_insulation.dm
+++ b/code/datums/components/rad_insulation.dm
@@ -20,6 +20,6 @@
 /datum/component/rad_insulation/proc/rad_contaminating(datum/source, strength)
 	return COMPONENT_BLOCK_CONTAMINATION
 
-/datum/component/rad_insulation/proc/rad_pass(datum/source, datum/radiation_wave/wave, index)
-	wave.intensity[index] *= amount
+/datum/component/rad_insulation/proc/rad_pass(datum/source, datum/radiation_wave/wave, width)
+	wave.intensity = wave.intensity*(1-((1-amount)/width)) // The further out the rad wave goes the less it's affected by insulation (larger width)
 	return COMPONENT_RAD_WAVE_HANDLED

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -7,6 +7,7 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 	var/source
+
 	var/hl3_release_date //the half-life measured in ticks
 	var/strength
 	var/can_contaminate
@@ -16,6 +17,7 @@
 	source = _source
 	hl3_release_date = _half_life
 	can_contaminate = _can_contaminate
+
 	if(istype(parent, /atom))
 		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/rad_examine)
 		if(istype(parent, /obj/item))
@@ -23,37 +25,27 @@
 			RegisterSignal(parent, COMSIG_ITEM_ATTACK_OBJ, .proc/rad_attack)
 	else
 		return COMPONENT_INCOMPATIBLE
-	if(strength * (RAD_CONTAMINATION_STR_COEFFICIENT * RAD_CONTAMINATION_BUDGET_SIZE) > RAD_COMPONENT_MINIMUM)
+
+	if(strength > RAD_MINIMUM_CONTAMINATION)
 		SSradiation.warn(src)
-	//Let's make er glow
-	//This relies on parent not being a turf or something. IF YOU CHANGE THAT, CHANGE THIS
-	var/atom/movable/master = parent
-	master.add_filter("rad_glow", 2, list("type" = "outline", "color" = "#39ff1430", "size" = 2))
-	addtimer(CALLBACK(src, .proc/glow_loop, master), rand(1,19))//Things should look uneven
+
 	START_PROCESSING(SSradiation, src)
 
 /datum/component/radioactive/Destroy()
 	STOP_PROCESSING(SSradiation, src)
-	var/atom/movable/master = parent
-	master.remove_filter("rad_glow")
 	return ..()
 
 /datum/component/radioactive/process()
 	if(!prob(50))
 		return
 	radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
+
 	if(!hl3_release_date)
 		return
 	strength -= strength / hl3_release_date
-
-	if(strength < RAD_WAVE_MINIMUM)
+	if(strength <= RAD_BACKGROUND_RADIATION)
 		qdel(src)
-
-/datum/component/radioactive/proc/glow_loop(atom/movable/master)
-	var/filter = master.get_filter("rad_glow")
-	if(filter)
-		animate(filter, alpha = 110, time = 15, loop = -1)
-		animate(alpha = 40, time = 25)
+		return PROCESS_KILL
 
 /datum/component/radioactive/InheritComponent(datum/component/C, i_am_original, list/arguments)
 	if(!i_am_original)
@@ -73,11 +65,11 @@
 		out += "The air around [master] feels warm"
 	switch(strength)
 		if(RAD_AMOUNT_LOW to RAD_AMOUNT_MEDIUM)
-			out += "[length(out) ? " and it " : "[master] "]feels weird to look at."
+			out += "[out ? " and it " : "[master] "]feels weird to look at."
 		if(RAD_AMOUNT_MEDIUM to RAD_AMOUNT_HIGH)
-			out += "[length(out) ? " and it " : "[master] "]seems to be glowing a bit."
+			out += "[out ? " and it " : "[master] "]seems to be glowing a bit."
 		if(RAD_AMOUNT_HIGH to INFINITY) //At this level the object can contaminate other objects
-			out += "[length(out) ? " and it " : "[master] "]hurts to look at."
+			out += "[out ? " and it " : "[master] "]hurts to look at."
 		else
 			out += "."
 	to_chat(user, out.Join())

--- a/code/datums/components/radioactive.dm
+++ b/code/datums/components/radioactive.dm
@@ -39,13 +39,14 @@
 	return ..()
 
 /datum/component/radioactive/process()
-	if(strength >= RAD_WAVE_MINIMUM)
-		radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT * RAD_DISTANCE_COEFFICIENT_COMPONENT_MULTIPLIER, FALSE, can_contaminate)
+	if(!prob(50))
+		return
+	radiation_pulse(parent, strength, RAD_DISTANCE_COEFFICIENT*2, FALSE, can_contaminate)
 	if(!hl3_release_date)
 		return
 	strength -= strength / hl3_release_date
 
-	if(strength < RAD_COMPONENT_MINIMUM)
+	if(strength < RAD_WAVE_MINIMUM)
 		qdel(src)
 
 /datum/component/radioactive/proc/glow_loop(atom/movable/master)
@@ -61,9 +62,9 @@
 		return
 	if(C)
 		var/datum/component/radioactive/other = C
-		strength += other.strength
+		strength = max(strength, other.strength)
 	else
-		strength += arguments[1]
+		strength = max(strength, arguments[1])
 
 /datum/component/radioactive/proc/rad_examine(datum/source, mob/user, atom/thing)
 	var/atom/master = parent

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -1,9 +1,8 @@
-
 /datum/radiation_wave
 	var/source
 	var/turf/master_turf //The center of the wave
-	var/steps = 0 //How far we've moved
-	var/intensity //How strong it is, except the distance falloff
+	var/steps=0 //How far we've moved
+	var/intensity //How strong it was originaly
 	var/range_modifier //Higher than 1 makes it drop off faster, 0.5 makes it drop off half etc
 	var/move_dir //The direction of movement
 	var/list/__dirs //The directions to the side of the wave, stored for easy looping
@@ -28,23 +27,23 @@
 
 /datum/radiation_wave/Destroy()
 	. = QDEL_HINT_IWILLGC
-
 	STOP_PROCESSING(SSradiation, src)
 	..()
 
 /datum/radiation_wave/process()
 	master_turf = get_step(master_turf, move_dir)
-	// If master_turf is no more, then we can't know where to irradiate. This is a very bad situation.
 	if(!master_turf)
 		qdel(src)
 		return
 	steps++
 	var/list/atoms = get_rad_atoms()
+
 	var/strength
 	if(steps>1)
-			strength = INVERSE_SQUARE(intensity, max(range_modifier*steps, 1), 1)
+		strength = INVERSE_SQUARE(intensity, max(range_modifier*steps, 1), 1)
 	else
-			strength = intensity
+		strength = intensity
+
 	if(strength < RAD_WAVE_MINIMUM)
 		qdel(src)
 		return
@@ -59,10 +58,10 @@
 	var/cmove_dir = move_dir
 	var/cmaster_turf = master_turf
 
-		if(cmove_dir == NORTH || cmove_dir == SOUTH)
-				distance-- //otherwise corners overlap
+	if(cmove_dir == NORTH || cmove_dir == SOUTH)
+		distance-- //otherwise corners overlap
 
-		atoms += get_rad_contents(cmaster_turf)
+	atoms += get_rad_contents(cmaster_turf)
 
 	var/turf/place
 	for(var/dir in __dirs) //There should be just 2 dirs in here, left and right of the direction of movement
@@ -71,7 +70,7 @@
 			place = get_step(place, dir)
 			atoms += get_rad_contents(place)
 
-		return atoms
+	return atoms
 
 /datum/radiation_wave/proc/check_obstructions(list/atoms)
 	var/width = steps
@@ -89,7 +88,6 @@
 		if (thing.rad_insulation != RAD_NO_INSULATION)
 			intensity *= (1-((1-thing.rad_insulation)/width))
 
-
 /datum/radiation_wave/proc/radiate(list/atoms, strength)
 	var/contamination_chance = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1, 1/(steps*range_modifier))
 	for(var/k in 1 to atoms.len)
@@ -103,6 +101,7 @@
 		// modify the ignored_things list in __HELPERS/radiation.dm instead
 		var/static/list/blacklisted = typecacheof(list(
 			/turf,
+			/mob,
 			/obj/structure/cable,
 			/obj/machinery/atmospherics,
 			/obj/item/ammo_casing,

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -1,53 +1,26 @@
-#define PRC_FLAG_HL		(1<<0)								// Send half of current strength to the upper "left"
-#define PRC_FLAG_L		(1<<1)								// Send the whole current strength to the upper "left": direct succession
-#define PRC_FLAG_HR		(1<<2)								// Send half of current strength to the upper "right"
-#define PRC_FLAG_R		(1<<3)								// Send the whole current strength to the upper "right": direct succession
-
-/**
- * Crash Course: Understanding PRC_BEHAVIOR
- * We move forward, and in square-by-square manner, so we need a list 8 entries larger than the current one, and future squares are determined from the current square.
- * We move clockwise: "left" means intensity_new[i + j], "right" means intensity_new[i + j + 1]. `j` here is offset.
- * Most squares are on branch: It moves "left"(L) or "right"(R).
- * But, sometimes, a branch can't decide which way to go; then it splits(D) and merges(HL, HR).
- * Then there are squares not on branch; those don't go anywhere else(N).
- * But branchless squares still need to act radiation; does branchless square's does one time transient succession from both of immediate predecessors
- * ... in contrast to "on-branch" squares where there are only one meaningful predecessor.
- * Since we are calculating future squares, we need to see if there are any branchless squares needing our attention: (*STAR)
- * And, of course, branchless squares might have to draw from another preceding branchless squares. (NWL, NWR)
- */
-
-#define PRC_BEHAVIOR_N			(1<<4)						// Not on branch, and both upper squares are on branch
-															// So we don't calculate prc_behavior every time (setting to 0 would do that)
-#define PRC_BEHAVIOR_NWL		PRC_FLAG_HL					// Not on branch, but will send half of its strength to the "left" since it also is not on branch
-#define PRC_BEHAVIOR_NWR		PRC_FLAG_HR					// Not on branch, but will send half of its strength to the "left" since it also is not on branch
-#define PRC_BEHAVIOR_L			PRC_FLAG_L					// On branch, going "left"
-#define PRC_BEHAVIOR_LSTAR		(PRC_FLAG_L|PRC_FLAG_HR)	// On branch, going "left", but there's branchless square on the "right"
-#define PRC_BEHAVIOR_R			PRC_FLAG_R					// On branch, going "right"
-#define PRC_BEHAVIOR_RSTAR		(PRC_FLAG_R|PRC_FLAG_HL)	// On branch, going "left", but there's branchless square on the "left"
-#define PRC_BEHAVIOR_D			(PRC_FLAG_L|PRC_FLAG_R)		// On branch, double successor.
-#define PRC_BEHAVIOR_HL			PRC_FLAG_HL					// From one of the double successor; single successor on the "left"
-#define PRC_BEHAVIOR_HLSTAR		(PRC_FLAG_HL|PRC_FLAG_HR)	// From one of the double successor; single successor on the "left", but there's branchless square on the "right"
-#define PRC_BEHAVIOR_HR			PRC_FLAG_HR					// From one of the double successor; single successor on the "right"
-#define PRC_BEHAVIOR_HRSTAR		(PRC_FLAG_HR|PRC_FLAG_HL)	// From one of the double successor; single successor on the "right", but there's branchless square on the "left"
 
 /datum/radiation_wave
 	var/source
 	var/turf/master_turf //The center of the wave
 	var/steps = 0 //How far we've moved
-	var/intensity[8] //How strong it is, except the distance falloff
+	var/intensity //How strong it is, except the distance falloff
 	var/range_modifier //Higher than 1 makes it drop off faster, 0.5 makes it drop off half etc
+	var/move_dir //The direction of movement
+	var/list/__dirs //The directions to the side of the wave, stored for easy looping
 	var/can_contaminate
-	var/static/list/prc_behavior_cache
 
-/datum/radiation_wave/New(atom/_source, _intensity=0, _range_modifier=RAD_DISTANCE_COEFFICIENT, _can_contaminate=TRUE)
+/datum/radiation_wave/New(atom/_source, dir, _intensity=0, _range_modifier=RAD_DISTANCE_COEFFICIENT, _can_contaminate=TRUE)
 
 	source = "[_source] \[[REF(_source)]\]"
 
 	master_turf = get_turf(_source)
 
-	// Yes, it causes (8 / range_modifier ** 2) times the strength you gave to the radiation_pulse().
-	for(var/i in 1 to 8)
-		intensity[i] = _intensity
+	move_dir = dir
+	__dirs = list()
+	__dirs+=turn(dir, 90)
+	__dirs+=turn(dir, -90)
+
+	intensity = _intensity
 	range_modifier = _range_modifier
 	can_contaminate = _can_contaminate
 
@@ -55,178 +28,70 @@
 
 /datum/radiation_wave/Destroy()
 	. = QDEL_HINT_IWILLGC
-	intensity = null
+
 	STOP_PROCESSING(SSradiation, src)
 	..()
 
 /datum/radiation_wave/process()
+	master_turf = get_step(master_turf, move_dir)
 	// If master_turf is no more, then we can't know where to irradiate. This is a very bad situation.
 	if(!master_turf)
 		qdel(src)
 		return
-	// If none of the turfs could be irradiated, then the wave should no longer exist
-	var/futile = TRUE
-	// Cache of unlucky atoms
-	var/list/atoms = list()
-	// The actual distance
-	var/distance = steps + 1
-	// Represents decreasing radiation power over distance
-	var/falloff = 1 / (distance * range_modifier) ** 2
-	// Caching
-	var/turf/cmaster_turf = master_turf
-	// Original intensity it is using
-	var/list/cintensity = intensity
-	// New intensity that'll be written; always larger than the previous one
-	var/list/intensity_new[(distance + 1) * 8]
-	// "Class" it belongs to
-	var/branchclass = 2 ** round(log(2, distance))
-	// The secondary i, or the offset for i
-	var/j
-
-	for(var/i in 1 to distance * 8)
-		//Culls invalid intensities
-		if(cintensity[i] * falloff < RAD_WAVE_MINIMUM)
-			continue
-		var/xpos
-		var/ypos
-		switch(i / distance)
-			if(0 to 2)
-				//Yes it starts one step off of what you'd expect. Blame BYOND.
-				xpos = cmaster_turf.x + distance
-				ypos = cmaster_turf.y + distance - i
-			if(2 to 4)
-				xpos = cmaster_turf.x + distance * 3 - i
-				ypos = cmaster_turf.y - distance
-			if(4 to 6)
-				xpos = cmaster_turf.x - distance
-				ypos = cmaster_turf.y - distance * 5 + i
-			if(6 to 8)
-				xpos = cmaster_turf.x - distance * 7 + i
-				ypos = cmaster_turf.y + distance
-		//Culls invalid coords
-		if(xpos < 1 || xpos > world.maxx || ypos < 1 || ypos > world.maxy)
-			continue
-
-		//The radiation is considered alive
-		futile = FALSE
-		var/turf/place = locate(xpos, ypos, cmaster_turf.z)
-		atoms = get_rad_contents(place)
-
-		//Actual radiation spending
-		cintensity[i] *= radiate(atoms, cintensity[i] * falloff)
-
-		//Obstruction handling
-		check_obstructions(atoms, i)
-
-		/*
-		 * This is what I call pseudo-raycasting (PRC). Real raycasting would be ridiculously expensive,
-		 * So this is the solution I came up with. Don't try to understand it by seeing the code.
-		 * You have been warned. If you find yourself really having to touch this cursed code,
-		 * consider axing this away before contacting me via git-fu email digging.
-		 *
-		 * Therefore, I urge you not to hastily assume this code a culprit of your problem.
-		 * This code is responsible just for *keeping the rads going forward* more reasonably
-		 * in regard to obstruction and contamination cost. But, of course, if you are rewriting
-		 * (notwithstanding how questionable rewriting something major of a mature codebase like
-		 * every normal SS13 codebase is) the entire radiation code, then this code should be
-		 * considered for deletion.
-		 *
-		 * On a side note, this implementation isn't very ideal. So please remove this instead of
-		 * trying to improve it when its time has come. (i.e. another total overhaul)
-		 *
-		 * ~Xenomedes, Christmas 2020
-		 */
-
-		// Handling eight fundamental (read: perfectly straight) branches
-		if((j = i / distance) == (j = round(j)))
-			distance + 1 == branchclass * 2 \
-			? (i == distance * 8 \
-				? (intensity_new[j - 1] += (intensity_new[1] += ((intensity_new[(j += i)] = cintensity[i]) / 2)) && cintensity[i] / 2) \
-				: (intensity_new[j - 1] += intensity_new[j + 1] = ((intensity_new[(j += i)] = cintensity[i]) / 2))) \
-			: (intensity_new[i + j] = cintensity[i])
-			continue
-
-		var/list/cachecache
-
-		if(!prc_behavior_cache)
-			prc_behavior_cache = list()
-		if(length(prc_behavior_cache) < distance)
-			prc_behavior_cache.len++
-			// We don't reserve spaces for fundamental branches
-			var/L[distance - 1]
-			// distance == 1 is where every ray is fundamental branch
-			cachecache = prc_behavior_cache[distance - 1] = L
-		else
-			cachecache = prc_behavior_cache[distance - 1]
-
-		// i % distance == 0 cases were already handled above
-		var/prc_behavior = cachecache[i % distance]
-
-		if(!prc_behavior)
-			// Necessary local variables
-			var/idx // index
-			var/lp // loop position
-			var/vl // velocity of loop
-			var/bt // branch threshold
-
-			// The actual behavior calculation
-			cachecache[i % distance] = prc_behavior = distance & 1 \
-				? ((lp = ((idx = i % distance) * (vl = distance - branchclass + 1)) % (distance + 1)) < (bt = branchclass - (idx - round(idx * vl / (distance + 1)))) \
-					? (lp \
-						? (lp + vl >= bt ? PRC_BEHAVIOR_LSTAR : PRC_BEHAVIOR_L) \
-						: (vl >= bt ? PRC_BEHAVIOR_HLSTAR : PRC_BEHAVIOR_HL)) \
-					: (lp > branchclass \
-						? (lp - vl <= bt ? PRC_BEHAVIOR_NWL : (lp - bt > branchclass ? PRC_BEHAVIOR_NWR : PRC_BEHAVIOR_N)) \
-						: (lp == branchclass \
-							? (lp - vl <= bt ? PRC_BEHAVIOR_HRSTAR : PRC_BEHAVIOR_HR) \
-							: (lp - vl <= bt ? PRC_BEHAVIOR_RSTAR : PRC_BEHAVIOR_R)))) \
-				: ((lp = ((idx = i % distance) * (vl = distance - branchclass + 1)) % (distance + 1)) == (bt = branchclass - (idx - round(idx * vl / (distance + 1)))) \
-					? PRC_BEHAVIOR_D \
-					: (lp > branchclass \
-						? (lp - vl <= bt ? PRC_BEHAVIOR_NWL : (lp - bt > branchclass ? PRC_BEHAVIOR_NWR : PRC_BEHAVIOR_N)) \
-						: (lp < bt \
-							? (lp + vl >= bt ? PRC_BEHAVIOR_LSTAR : PRC_BEHAVIOR_L) \
-							: (lp - vl <= bt ? PRC_BEHAVIOR_RSTAR : PRC_BEHAVIOR_R))))
-
-		prc_behavior & PRC_FLAG_HL \
-		? (intensity_new[i + j] += cintensity[i] / 2) \
-		: (prc_behavior & PRC_FLAG_L \
-		? (intensity_new[i + j] = cintensity[i]) \
-		: null)
-
-		prc_behavior & PRC_FLAG_HR \
-		? (intensity_new[i + j + 1] += cintensity[i] / 2) \
-		: (prc_behavior & PRC_FLAG_R \
-		? (intensity_new[i + j + 1] = cintensity[i]) \
-		: null)
-
-	if(futile)
+	steps++
+	var/list/atoms = get_rad_atoms()
+	var/strength
+	if(steps>1)
+			strength = INVERSE_SQUARE(intensity, max(range_modifier*steps, 1), 1)
+	else
+			strength = intensity
+	if(strength < RAD_WAVE_MINIMUM)
 		qdel(src)
 		return
 
-	// Now is time to move forward
-	intensity = intensity_new
-	steps++
+	radiate(atoms, FLOOR(strength, 1))
 
-/datum/radiation_wave/proc/check_obstructions(list/atoms, index)
+	check_obstructions(atoms) // reduce our overall strength if there are radiation insulators
+
+/datum/radiation_wave/proc/get_rad_atoms()
+	var/list/atoms = list()
+	var/distance = steps
+	var/cmove_dir = move_dir
+	var/cmaster_turf = master_turf
+
+		if(cmove_dir == NORTH || cmove_dir == SOUTH)
+				distance-- //otherwise corners overlap
+
+		atoms += get_rad_contents(cmaster_turf)
+
+	var/turf/place
+	for(var/dir in __dirs) //There should be just 2 dirs in here, left and right of the direction of movement
+		place = cmaster_turf
+		for(var/i in 1 to distance)
+			place = get_step(place, dir)
+			atoms += get_rad_contents(place)
+
+		return atoms
+
+/datum/radiation_wave/proc/check_obstructions(list/atoms)
+	var/width = steps
+	var/cmove_dir = move_dir
+	if(cmove_dir == NORTH || cmove_dir == SOUTH)
+		width--
+	width = 1+(2*width)
+
 	for(var/k in 1 to atoms.len)
 		var/atom/thing = atoms[k]
 		if(!thing)
 			continue
-		if (SEND_SIGNAL(thing, COMSIG_ATOM_RAD_WAVE_PASSING, src, index) & COMPONENT_RAD_WAVE_HANDLED)
+		if (SEND_SIGNAL(thing, COMSIG_ATOM_RAD_WAVE_PASSING, src, width) & COMPONENT_RAD_WAVE_HANDLED)
 			continue
 		if (thing.rad_insulation != RAD_NO_INSULATION)
-			intensity[index] *= thing.rad_insulation
+			intensity *= (1-((1-thing.rad_insulation)/width))
 
-// Returns post-radiation strength power scale of a ray
-// If this proc returns a number lower than 1, it means that the some radiation was spent on contaminating something.
+
 /datum/radiation_wave/proc/radiate(list/atoms, strength)
-	// returning 1 means no radiation was spent on contamination
-	. = 1
-	var/list/moblist = list()
-	var/list/atomlist = list()
-	var/contam_strength = strength * (RAD_CONTAMINATION_STR_COEFFICIENT * RAD_CONTAMINATION_BUDGET_SIZE) // The budget for each list
-	var/is_contaminating = contam_strength > RAD_COMPONENT_MINIMUM && can_contaminate
+	var/contamination_chance = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1, 1/(steps*range_modifier))
 	for(var/k in 1 to atoms.len)
 		var/atom/thing = atoms[k]
 		if(!thing)
@@ -244,45 +109,12 @@
 			/obj/item/implant,
 			/obj/singularity
 			))
-		// Insulating objects won't get contaminated
-		if(!is_contaminating || blacklisted[thing.type] || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
+		if(!can_contaminate || blacklisted[thing.type])
 			continue
-		if(ismob(thing))
-			moblist += thing
-		else
-			atomlist += thing
+		if(prob(contamination_chance)) // Only stronk rads get to have little baby rads
+			if(SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
+				continue
+			var/rad_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
 
-	// We don't randomly choose one from the list since that can result in zero meaningful contamination
-
-	if(atomlist.len)
-		. -= RAD_CONTAMINATION_BUDGET_SIZE
-		var/affordance = min(round(contam_strength / RAD_COMPONENT_MINIMUM), atomlist.len)
-		var/contam_strength_divided = contam_strength / affordance
-		for(var/k in 1 to affordance)
-			var/atom/poor_thing = atomlist[k]
-			poor_thing.AddComponent(/datum/component/radioactive, contam_strength_divided, source)
-
-	if(moblist.len)
-		. -= RAD_CONTAMINATION_BUDGET_SIZE
-		var/affordance = min(round(contam_strength / RAD_COMPONENT_MINIMUM), moblist.len)
-		var/contam_strength_divided = contam_strength / affordance
-		for(var/k in 1 to affordance)
-			var/mob/poor_mob = moblist[k]
-			poor_mob.AddComponent(/datum/component/radioactive, contam_strength_divided, source)
-
-#undef PRC_FLAG_HL
-#undef PRC_FLAG_L
-#undef PRC_FLAG_HR
-#undef PRC_FLAG_R
-#undef PRC_BEHAVIOR_N
-#undef PRC_BEHAVIOR_NWL
-#undef PRC_BEHAVIOR_NWR
-#undef PRC_BEHAVIOR_L
-#undef PRC_BEHAVIOR_LSTAR
-#undef PRC_BEHAVIOR_R
-#undef PRC_BEHAVIOR_RSTAR
-#undef PRC_BEHAVIOR_D
-#undef PRC_BEHAVIOR_HL
-#undef PRC_BEHAVIOR_HLSTAR
-#undef PRC_BEHAVIOR_HR	
-#undef PRC_BEHAVIOR_HRSTAR
+			if (rad_strength >= RAD_WAVE_MINIMUM) // Don't even bother to add the component if its waves aren't going to do anything
+				thing.AddComponent(/datum/component/radioactive, rad_strength, source)


### PR DESCRIPTION
## Do remember I'm not sure if it has test merge issues
Bee had a nerf regarding how the entire calculation of radiation works, I just added the former radiation calculation because it's kinda funny.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

I fully changed the calculations of the radiation system to the former one..

## Why It's Good For The Game

<!---->
Radiation currently isn't a major threat and is really kinda lame. There's not a lot of engineers that are skilled enough to make radiation a giant threat

## Changelog
:cl: Acensti - Reverted the rad new calculations and how radiation works to the former calculation system that was changed in 2020. 

:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
