### PR TITLE
Fixed simplemobs opening airlocks

### DIFF
--- a/Oasis/SCP_MAIN/code/game/machinery/doors/airlock.dm
+++ b/Oasis/SCP_MAIN/code/game/machinery/doors/airlock.dm
@@ -1,22 +1,25 @@
-/obj/machinery/door/airlock/attack_animal(mob/living/simple_animal/hostile/statue/scp_173/user)
-	add_fingerprint(user)
-	if(isElectrified())
-		shock(user, 100) //Mmm, fried xeno!
-		return
-	if(!density) //Already open
-		return
-	if(locked || welded) //Extremely generic, as aliens only understand the basics of how airlocks work.
-		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
-		return
-	user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
-						"<span class='noticealien'>You begin prying [src] open with all your might!</span>",\
-						"<span class='warning'>You hear groaning metal...</span>")
-	var/time_to_open = 5
-	if(hasPower())
-		time_to_open = 15 //Powered airlocks take longer to open, and are loud.
-		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
+/obj/machinery/door/airlock/attack_animal(mob/living/simple_animal/user)
+	if(istype(user, /mob/living/simple_animal/hostile/statue/scp_173))
+		add_fingerprint(user)
+		if(isElectrified())
+			shock(user, 100) //Mmm, fried xeno!
+			return
+		if(!density) //Already open
+			return
+		if(locked || welded) //Extremely generic, as aliens only understand the basics of how airlocks work.
+			to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
+			return
+		user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
+							"<span class='noticealien'>You begin prying [src] open with all your might!</span>",\
+							"<span class='warning'>You hear groaning metal...</span>")
+		var/time_to_open = 5
+		if(hasPower())
+			time_to_open = 15 //Powered airlocks take longer to open, and are loud.
+			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
 
 
-	if(do_after(user, time_to_open, TRUE, src))
-		if(density && !open(2)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
-			to_chat(user, "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>")
+		if(do_after(user, time_to_open, TRUE, src))
+			if(density && !open(2)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
+				to_chat(user, "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>")
+	else
+		..()

--- a/Oasis/SCP_MAIN/code/game/machinery/doors/firelock.dm
+++ b/Oasis/SCP_MAIN/code/game/machinery/doors/firelock.dm
@@ -1,19 +1,22 @@
-/obj/machinery/door/firedoor/attack_animal(mob/living/simple_animal/hostile/statue/scp_173/user)
-	add_fingerprint(user)
-	if(!density) //Already open
-		return
-	if(locked || welded) //Extremely generic, as aliens only understand the basics of how airlocks work.
-		to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
-		return
-	user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
-						"<span class='noticealien'>You begin prying [src] open with all your might!</span>",\
-						"<span class='warning'>You hear groaning metal...</span>")
-	var/time_to_open = 1
-	if(hasPower())
-		time_to_open = 1 //Powered airlocks take longer to open, and are loud.
-		playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
+/obj/machinery/door/firedoor/attack_animal(mob/living/simple_animal/user)
+	if(istype(user, /mob/living/simple_animal/hostile/statue/scp_173))
+		add_fingerprint(user)
+		if(!density) //Already open
+			return
+		if(locked || welded) //Extremely generic, as aliens only understand the basics of how airlocks work.
+			to_chat(user, "<span class='warning'>[src] refuses to budge!</span>")
+			return
+		user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
+							"<span class='noticealien'>You begin prying [src] open with all your might!</span>",\
+							"<span class='warning'>You hear groaning metal...</span>")
+		var/time_to_open = 1
+		if(hasPower())
+			time_to_open = 1 //Powered airlocks take longer to open, and are loud.
+			playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
 
 
-	if(do_after(user, time_to_open, TRUE, src))
-		if(density && !open(2)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
-			to_chat(user, "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>")
+		if(do_after(user, time_to_open, TRUE, src))
+			if(density && !open(2)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
+				to_chat(user, "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>")
+	else
+		..()

--- a/Oasis/SCP_MAIN/code/game/machinery/doors/poddoor.dm
+++ b/Oasis/SCP_MAIN/code/game/machinery/doors/poddoor.dm
@@ -1,4 +1,7 @@
-/obj/machinery/door/poddoor/attack_animal(mob/living/simple_animal/hostile/statue/scp_173/user)
-	add_fingerprint(user)
-	user.visible_message("<span class='warning'>[src] refuses to budge!</span>")
-	return
+/obj/machinery/door/poddoor/attack_animal(mob/living/simple_animal/user)
+	if(istype(user, /mob/living/simple_animal/hostile/statue/scp_173))
+		add_fingerprint(user)
+		user.visible_message("<span class='warning'>[src] refuses to budge!</span>")
+		return
+	else
+		..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Simple mobs (expect scp-173) won't be able to pry open airlocks anymore.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No more mice marching into SM pulling welding fuel tanks.
Oh wait, that's definitely bad for the game, don't merge it.

## Changelog
:cl:
fix: fixed simple mobs prying open airlocks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
