### PR TITLE
Fixed shoepacabra eating magboots and being handcuffed

### DIFF
--- a/Oasis/code/modules/mob/living/carbon/shoepacabra/forms/greater.dm
+++ b/Oasis/code/modules/mob/living/carbon/shoepacabra/forms/greater.dm
@@ -6,7 +6,6 @@
 
 	clawed = TRUE
 	can_tackle = TRUE
-	can_aggrograb = TRUE
 
 	shoes_healing_amount = 15
 

--- a/Oasis/code/modules/mob/living/carbon/shoepacabra/shoepacabra.dm
+++ b/Oasis/code/modules/mob/living/carbon/shoepacabra/shoepacabra.dm
@@ -9,7 +9,6 @@
 	var/form = "lesser"  // The postfix used generally for icon state determination
 	var/clawed = FALSE  // Determines if the creature is using xeno-like claws
 	var/can_tackle = FALSE  // Determines if the creature is capable of tackling the opponent instead of pushing it
-	var/can_aggrograb = FALSE  // Determines if the creature is capable of aggressively grabbing the opponent <TODO> NOT IMPLEMENTED YET
 	var/bloodthirsty = FALSE  // Determines if the creature should maim people when stealing shoes with harm intent
 
 	article = "el"
@@ -101,6 +100,13 @@
 /mob/living/carbon/shoepacabra/can_hold_items()
 	return TRUE
 
+/* Is consumable footwear
+Check if shoepacabra can consume the footwear.
+Accepts:
+	F, the footwear
+Returns:
+	TRUE if the footwear can be consumed, FALSE otherwise
+*/
 /proc/is_consumable_footwear(obj/item/clothing/shoes/F)
 	if (F.resistance_flags & (ACID_PROOF | INDESTRUCTIBLE))  // Make sure our little rascal doesn't ruin some antag's day
 		return FALSE
@@ -110,6 +116,9 @@
 		return FALSE
 	return TRUE
 
+/mob/living/carbon/shoepacabra/canBeHandcuffed()
+	return FALSE
+
 /* Consume footwear
 Creature makes an attempt to consume the given footwear.
 Accepts:
@@ -117,7 +126,8 @@ Accepts:
 */
 /mob/living/carbon/shoepacabra/proc/consume_footwear(obj/item/clothing/shoes/F, instantly = FALSE)
 	if (!is_consumable_footwear(F))
-		to_chat(src, "<span class='notice'>As you take a bite you notice that [F] is way too robust for you to consume!</span>")
+		to_chat(src, "<span class='warning'>As you take a bite you notice that [F] is way too robust for you to consume!</span>")
+		return
 
 	instantly = instantly || (shoes_consumption_delay <= 0)
 	if (!instantly)  // meh double check

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -55,7 +55,7 @@
 		M = C
 		M.retaliate(user)
 
-	if(!C.handcuffed)
+	if(!C.handcuffed && C.canBeHandcuffed())
 		if(C.get_num_arms(FALSE) >= 2 || C.get_arm_ignore())
 			C.visible_message("<span class='danger'>[user] is trying to put [src.name] on [C]!</span>", \
 								"<span class='userdanger'>[user] is trying to put [src.name] on you!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

El shoepacabra is no longer able to eat magboots and bronze shoes.
Handcuffs are now using canBeHandcuffed proc (I wonder what monkey wrote it without this check) so shoepacabras, high devils and other carbons with canBeHandcuffed returning FALSE are no longer handcuffable.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

No more shoepacabras ruining anatg objectives.
No more high devils being handcuffed.

## Changelog
:cl:
fix: fixed shoepacabras eating magboots
fix: fixed handcuffing carbons that can't be handcuffed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
